### PR TITLE
Add issues to fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -10,7 +10,8 @@
   ],
   "contact": {
     "homepage": "https://fabricmc.net/",
-    "sources": "https://github.com/FabricMC/fabric-example-mod"
+    "sources": "https://github.com/FabricMC/fabric-example-mod",
+    "issues": "https://github.com/RedstoneQoL/mod/issues"
   },
 
   "license": "CC0-1.0",


### PR DESCRIPTION
Its great to have a way to report issues from a mod. So its best to add a issues site link to the mod.